### PR TITLE
JNG-4086 '+' and '-' unary operators added

### DIFF
--- a/docs/pages/01_jsl.adoc
+++ b/docs/pages/01_jsl.adoc
@@ -1128,6 +1128,8 @@ An operator also returns a value. The value and its type depends on the operator
 We can divide operators into these categories:
 
 // * assignment (`=`,`+=`,`-=`)
+* navigation, field selection and query execution (`.`)
+* function call (`!`)
 * assignment (`=`)
 * arithmetic (`+`, `-`, `*`, `/`, `div`, `mod`, `^`)
 * relational (`==`,`!=`,`<`,`>`,`>=`,`\<=`)
@@ -1139,17 +1141,17 @@ The following table summarizes the precedence of operators used in expressions.
 [options="header", cols="1,2"]
 |====================
 |Precedence |Operator
-|10         |`()`
-|9          |`not`
+|10         |`()`, `.`, `!`
+|9          |```not```
 |8          |`*`, `/`, `div`, `mod`
 |7          |`+`, `-`
 |6          |`>`, `<`, `\<=`, `>=`
 |5          |`==`, `!=`
-|4          |`and`
-|3          |`or`
-|2          |`? :`
+|4          |```and```
+|3          |```or```
+|2          |```?``` ```:```
 // |1          |`=`, `+=`, `-=`
-|1          |`=`
+|1          |```=```
 |====================
 
 === Navigation

--- a/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/ModifiersTests.xtend
+++ b/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/ModifiersTests.xtend
@@ -18,22 +18,6 @@ class ModifiersTests {
 	@Inject extension ParseHelper<ModelDeclaration> 
 	@Inject extension ValidationTestHelper
 	
-	@Test
-	def void testMinSizeModifierNegative() {
-		'''
-			model test;
-			
-			type string String(min-size = -1, max-size = 128);
-			
-			entity Person{
-				field String fullName;
-			}
-
-		'''.parse => [
-			assertMinSizeNegativeError("min-size must be greater than or equal to 0", JsldslPackage::eINSTANCE.modifierMinSize)
-		]
-	}
-	
 	@Test 
 	def void testMinSizeModifierTooLarge() {
 		'''
@@ -67,11 +51,11 @@ class ModifiersTests {
 	}
 
 	@Test
-	def void testMaxSizeModifierNegative() {
+	def void testMaxSizeModifierZero() {
 		'''
 			model test;
 			
-			type string String(min-size = 0, max-size = -1);
+			type string String(min-size = 0, max-size = 0);
 			
 			entity Person{
 				field String fullName;
@@ -136,21 +120,6 @@ class ModifiersTests {
 		]
 	}
 	
-	@Test
-	def void testScaleModifierTooLow() {
-		'''
-			model test;
-			
-			type numeric Number1(precision = 15, scale = -1);
-			
-			entity Entity {
-				field Number1 number;
-			}
-		'''.parse => [
-			m | m.assertError(JsldslPackage::eINSTANCE.modifierScale, JslDslValidator.SCALE_MODIFIER_IS_NEGATIVE, "Scale must be greater than/equal to 0")
-		]
-	}
-
 	@Test
 	def void testScaleModifierTooLarge() {
 		'''

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
@@ -313,8 +313,8 @@ SpawnOperation returns Expression
 	;
 
 UnaryOperation returns Expression
-	: {UnaryOperation} operator=('not' | '-') operand=FunctionedExpression
-    | FunctionedExpression
+	: {UnaryOperation} operator=('not' | '-' | '+') operand=UnaryOperation
+	| FunctionedExpression
     ;
 
 FunctionedExpression returns Expression
@@ -590,11 +590,11 @@ terminal DATE
 	;
 
 terminal DECIMAL returns ecore::EBigDecimal
-	: '-'? DIGIT+ '.' DIGIT+
+	: DIGIT+ '.' DIGIT+
 	;
 
 terminal INTEGER returns ecore::EBigInteger
-	: '-'? DIGIT+
+	: DIGIT+
 	;
 
 terminal ID


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4086" title="JNG-4086" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4086</a>  '+' is missing in unary operators, wrong number terminal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
