### PR TITLE
JNG-4293 Consistent lpad-rpad cutting

### DIFF
--- a/docs/pages/06_expression.adoc
+++ b/docs/pages/06_expression.adoc
@@ -560,7 +560,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**lpad(size = **#<size> &#x5B;[purple]##**, padstring = **##<padstring>][purple]##**)**## : string`
-|Fills up a string on the left to the specified <size> with <padstring>. If the string's length is less then than the specified <size> the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
+|Fills up a string on the left to the specified <size> with <padstring>. If the specified <size> is less than the string's length, the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!lpad(size = 6) is `" apple"`
 |`"apple"!lpad(size = 2) is `"ap"`
@@ -572,7 +572,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**rpad(size = **#<size> &#x5B;[purple]##**, padstring = **##<padstring>][purple]##**)**## : string`
-|Fills up a string on the right to the specified <size> with <padstring>. If the string's length is less then than the specified <size> the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the left. If <padstring> is not defined, one space character (`" "`) is used by default.
+|Fills up a string on the right to the specified <size> with <padstring>. If the specified <size> is less than the string's length, the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the left. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!rpad(size = 6)` is `"apple "`
 |`"apple"!rpad(size = 2) is `"ap"`

--- a/docs/pages/06_expression.adoc
+++ b/docs/pages/06_expression.adoc
@@ -563,6 +563,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 |Fills up a string on the left to the specified <size> with <padstring>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!lpad(size = 6) is `" apple"`
+|`"apple"!lpad(size = 2) is `"ap"`
 |`"ple"!lpad(size = 5, padstring = "ap")` is `"apple"`
 |`"ple"!lpad(size = 6, padstring = "ap")` is `"apaple"`
 |`"ple"!lpad(size = 7, padstring = "ap")` is `"apapple"`
@@ -571,9 +572,10 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**rpad(size = **#<size> &#x5B;[purple]##**, padstring = **##<padstring>][purple]##**)**## : string`
-|Fills up a string on the right to the specified <size> with <padstring>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the left. If <padstring> is not defined, one space character (`" "`) is used by default.
+|Fills up a string on the right to the specified <size> with <padstring>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!rpad(size = 6)` is `"apple "`
+|`"apple"!rpad(size = 2) is `"ap"`
 |`"app"!rpad(size = 5, padstring = "le")` is `"apple"`
 |`"app"!rpad(size = 6, padstring = "le")` is `"applel"`
 |`"app"!rpad(size = 7, padstring = "le")` is `"applele"`

--- a/docs/pages/06_expression.adoc
+++ b/docs/pages/06_expression.adoc
@@ -560,7 +560,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**lpad(size = **#<size> &#x5B;[purple]##**, padstring = **##<padstring>][purple]##**)**## : string`
-|Fills up a string on the left to the specified <size> with <padstring>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
+|Fills up a string on the left to the specified <size> with <padstring>. If the string's length is less then than the specified <size> the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!lpad(size = 6) is `" apple"`
 |`"apple"!lpad(size = 2) is `"ap"`
@@ -572,7 +572,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**rpad(size = **#<size> &#x5B;[purple]##**, padstring = **##<padstring>][purple]##**)**## : string`
-|Fills up a string on the right to the specified <size> with <padstring>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the right. If <padstring> is not defined, one space character (`" "`) is used by default.
+|Fills up a string on the right to the specified <size> with <padstring>. If the string's length is less then than the specified <size> the string is truncated from the right to the specified <size>. If the length of <padstring> is less than the remaining length, the <padstring> is repeated until it is not filling up. If the length of <padstring> is longer than the remaining length, it will be truncated on the left. If <padstring> is not defined, one space character (`" "`) is used by default.
 |Examples:
 |`"apple"!rpad(size = 6)` is `"apple "`
 |`"apple"!rpad(size = 2) is `"ap"`


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4293" title="JNG-4293" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4293</a>  lpad function returns wrong value while using PSQL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

