### PR TITLE
JNG-3902 Fix timestamp asstring

### DIFF
--- a/docs/pages/04_types.adoc
+++ b/docs/pages/04_types.adoc
@@ -484,7 +484,7 @@ Time literals can be represented as literals using the following syntax.
 
 [subs="quotes"]
 ----
-[purple]##**\`**##&lt;hh>[purple]##**:**##&lt;mm>&#x5B;[purple]##**:**##&lt;ss>][purple]##**`**##
+[purple]##**\`**##&lt;hh>[purple]##**:**##&lt;mm>&#x5B;[purple]##**:**##&lt;ss>[.&lt;ff>]][purple]##**`**##
 ----
 
 where
@@ -492,9 +492,10 @@ where
 * <hh> refers to a zero-padded hour between 00 and 23,
 * <mm> refers to a zero-padded minute between 00 and 59,
 * <ss> refers to a zero-padded second between 00 and 59,
+* <ff> refers to fractional second (millisecond) between 000 and 999 (trailing zeros can be omitted: `12:23:56.100 = 12:23:56.1`),
 * the surrounding backticks are required.
 
-The valid values of time are between `pass:[`00:00:00`]` and `pass:[`23:59:59`]`.
+The valid values of time are between `pass:[`00:00:00.000`]` (or `pass:[`00:00`]`) and `pass:[`23:59:59.999`]`.
 
 The following examples are valid time literals.
 
@@ -502,8 +503,12 @@ The following examples are valid time literals.
 
 [source,jsl]
 ----
-`23:59:59`
 `23:59`
+`23:59:59`
+`23:59:59.789`
+`23:59:59.100`
+`23:59:59.1`
+`23:59:59.001`
 ----
 
 To define time primitive, use the `type` keyword with `time`.
@@ -551,11 +556,22 @@ Timestamp is a value identifying when a certain event occurred or when a certain
 
 Timestamp is surrounded by backticks ( ` ) and formatted using ISO-8601 standard, for example
 
+`pass:[`2020-02-18T10:11`]`
+
+`pass:[`2020-02-18T10:11:12`]`
+
 `pass:[`2020-02-18T10:11:12Z`]`
 
 `pass:[`2019-07-18T11:11:12+02:00`]`
 
 `pass:[`2019-07-18T11:11:12.003+02:00`]`
+
+`pass:[`2019-07-18T11:11:12.003+02`]`
+
+[WARNING]
+====
+Timestamps are stored without time zone information, therefore Timestamps created with backticks (`) that contain zone offsets are always converted to UTC.
+====
 
 To define timestamp primitive, use the `type` keyword with `timestamp`.
 
@@ -574,6 +590,8 @@ where the <name> is the name of the domain model timestamp.
 ----
 type timestamp Timestamp;
 ----
+
+////
 
 Some timestamp functions may expect time zone information as input. Use the following format to specify the time zone:
 
@@ -596,6 +614,8 @@ where
 ----
 `+02:00`
 ----
+
+////
 
 You can find a detailed explanation of the operators and their precedence in the xref:06_expression.adoc#operators[Operators] chapter. The supported operators of timestamp are the following:
 

--- a/docs/pages/06_expression.adoc
+++ b/docs/pages/06_expression.adoc
@@ -742,12 +742,13 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
-|`[purple]#**of(hour = **#<hour>[purple]##**, minute = **## <minute>[purple]##**[, second = **## <second>[purple]##**[, millisecond = **## <millisecond>[purple]##**]])**## : time`
+|`[purple]#**of(hour = **#<hour>[purple]##**, minute = **## <minute>[purple]##**[, second = **## <second>[purple]##**][, millisecond = **## <millisecond>[purple]##**])**## : time`
 |Static function, constructs a time value from the numeric parameters <hour>, <minute>, <second> and <millisecond>. If any of the parameters is not integer, the result will be undefined. If any parameter is less than 0, the result will be undefined. If <hour> is greater than 23, <minute> or <second> is greater than 59 or <millisecond> is greater than 999, it gives an undefined result.
 |Example::
 * `Time!of(hour = 13, minute = 45)` is `&#x60;13:45&#x60;`
 * `Time!of(hour = 13, minute = 45, second = 77)` is `&#x60;13:45:77&#x60;`
 * `Time!of(hour = 13, minute = 45, second = 77, millisecond = 444)` is `&#x60;13:45:77.444&#x60;`
+* `Time!of(hour = 13, minute = 45, millisecond = 444)` is `&#x60;13:45:00.444&#x60;`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]

--- a/docs/pages/06_expression.adoc
+++ b/docs/pages/06_expression.adoc
@@ -477,14 +477,15 @@ Any type functions can be applied to any type or instance except collections.
 |Returns the original string with all alphabetic characters in uppercase. Note that the actual locale of the database affects the behavior of this function. 
 |Example: `"ApPlE"!upper()` is `"APPLE"`
 |======================================================================
-
+////
+TODO: https://blackbelt.atlassian.net/browse/JNG-4087
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**capitalize()**# : string`
 |Returns a string with the first letter capitalized and all other characters lowercased. Note that the actual locale of the database affects the behavior of this function.
 |Example: `"apPlE"!capitalize()` is `"Apple"`
 |======================================================================
-
+////
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**matches(pattern = **#<pattern>[purple]##**)**## : boolean`
@@ -727,23 +728,50 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
-|`[purple]#**now()**# : time`
-|Static function, returns the current time.
-|Example: `Time!now()` is `&#x60;13:45:00&#x60;`
+|`[purple]#**millisecond()**# : numeric`
+|Returns the millisecond part of time.
+|Example: `&#x60;23:15:59.789&#x60;!millisecond()` is `789`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
-|`[purple]#**of(hour = **#<hour>[purple]##**, minute = **## <minute>[purple]##**, second = **## <second>[purple]##**)**## : time`
-|Static function, constructs a time value from the numeric parameters <hour>, <minute> and <second>. If any of the parameters is not integer, the result will be undefined. If any parameter is less than 0, the result will be undefined. If <hour> is greater than 23, or <minute> or <second> is greater than 59, it gives an undefined result.
-|Example: `Time!of(hour = 13, minute = 45, second = 00)` is `&#x60;13:45:00&#x60;`
+|`[purple]#**now()**# : time`
+|Static function, returns the current time.
+|Example: `Time!now()` is `&#x60;13:45&#x60;`
+|======================================================================
+
+[options="header",grid="none",cols="1a"]
+|======================================================================
+|`[purple]#**of(hour = **#<hour>[purple]##**, minute = **## <minute>[purple]##**[, second = **## <second>[purple]##**[, millisecond = **## <millisecond>[purple]##**]])**## : time`
+|Static function, constructs a time value from the numeric parameters <hour>, <minute>, <second> and <millisecond>. If any of the parameters is not integer, the result will be undefined. If any parameter is less than 0, the result will be undefined. If <hour> is greater than 23, <minute> or <second> is greater than 59 or <millisecond> is greater than 999, it gives an undefined result.
+|Example::
+* `Time!of(hour = 13, minute = 45)` is `&#x60;13:45&#x60;`
+* `Time!of(hour = 13, minute = 45, second = 77)` is `&#x60;13:45:77&#x60;`
+* `Time!of(hour = 13, minute = 45, second = 77, millisecond = 444)` is `&#x60;13:45:77.444&#x60;`
+|======================================================================
+
+[options="header",grid="none",cols="1a"]
+|======================================================================
+|`[purple]#**asMilliseconds()**# : numeric`
+|Returns the time in milliseconds from 00:00, midnight.
+|Example: `&#x60;00:01&#x60;!asMilliseconds()` is `60000`
+|======================================================================
+
+[options="header",grid="none",cols="1a"]
+|======================================================================
+|`[purple]#**fromMilliseconds(milliseconds = **#<milliseconds>[purple]##**)**## : time`
+|Static function, creates a time and sets the value in <milliseconds> from 00:00, midnight. <milliseconds> must be an integer
+|Example: `Time!fromMilliseconds(milliseconds = 60000)` is `&#x60;00:01&#x60;`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**asString()**# : string`
 |Time value as string according to the ISO-8601 standard.
-|Example: `&#x60;23:15:59&#x60;!asString()` is `"23:15:59"`
+|Example::
+* `&#x60;23:15:00.000&#x60;!asString()` is `"23:15"`
+* `&#x60;23:15:59.000&#x60;!asString()` is `"23:15:59"`
+* `&#x60;23:15:59.789&#x60;!asString()` is `"23:15:59.789"`
 |======================================================================
 
 [#timestamp_functions,judo-req="true",judo-req-id="REQ-EXPR-018"]
@@ -752,18 +780,18 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**date()**# : date`
-|Returns the date part of the timestamp in UTC+0 timezone.
+|Returns the date part of the timestamp.
 |Example:
-|`&#x60;2019-07-18T01:11:12Z&#x60;!date()` is `&#x60;2019-07-18&#x60;`
+|`&#x60;2019-07-18T01:11:12&#x60;!date()` is `&#x60;2019-07-18&#x60;`
 |`&#x60;2019-07-18T01:11:12+02:00&#x60;!date()` is `&#x60;2019-07-17&#x60;`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**time()**# : time`
-|Returns the time part of the timestamp in UTC+0 timezone.
+|Returns the time part of the timestamp.
 |Example:
-|`&#x60;2019-07-18T01:11:12Z&#x60;!time()` is `&#x60;01:11:12&#x60;`
+|`&#x60;2019-07-18T01:11:12&#x60;!time()` is `&#x60;01:11:12&#x60;`
 |`&#x60;2019-07-18T01:11:12+02:00&#x60;!time()` is `&#x60;23:11:12&#x60;`
 |======================================================================
 
@@ -771,7 +799,7 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 |======================================================================
 |`[purple]#**now()**# : timestamp`
 |Static function, returns the current date and time.
-|Example: `Timestamp!now()` is `&#x60;2021-02-28T00:00:00Z&#x60;`
+|Example: `Timestamp!now()` is `&#x60;2021-02-28T00:00&#x60;`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
@@ -779,22 +807,22 @@ The percent sign represents zero, one, or multiple numbers or characters. The un
 |`[purple]#**of(date = **#<date> &#x5B;[purple]##**, time = **##<time>][purple]##**)**## : timestamp`
 |Static function, constructs a timestamp value from the parameters <date> and <time>, where <date> is a date primitive and <time> is a time primitive. The <time> parameter is optional, if <time> is omitted the time part of the timestamp will be set to `&#x60;00:00:00&#x60;`.
 |Example:
-|`Timestamp!of(date = &#x60;2021-02-28&#x60;, time = &#x60;10:30:01&#x60;)` is `&#x60;2021-02-28T10:30:01Z&#x60;`
-|`Timestamp!of(date = &#x60;2021-02-28&#x60;)` is `&#x60;2021-02-28T00:00:00Z&#x60;`
+|`Timestamp!of(date = &#x60;2021-02-28&#x60;, time = &#x60;10:30:01&#x60;)` is `&#x60;2021-02-28T10:30:01&#x60;`
+|`Timestamp!of(date = &#x60;2021-02-28&#x60;)` is `&#x60;2021-02-28T00:00&#x60;`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**asMilliseconds()**# : numeric`
-|Returns the timestamp in milliseconds from 1970-01-01T00:00:00Z.
+|Returns the timestamp in milliseconds from 1970-01-01T00:00.
 |Example: `&#x60;1970-01-01T00:01:00Z&#x60;!asMilliseconds()` is `60000`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**fromMilliseconds(milliseconds = **#<milliseconds>[purple]##**)**## : timestamp`
-|Static function, creates a timestamp and sets the value in <milliseconds> from 1970-01-01T00:00:00Z. <milliseconds> must be an integer
-|Example: `Timestamp!fromMilliseconds(milliseconds = 60000)` is `&#x60;1970-01-01T00:01:00Z&#x60;`
+|Static function, creates a timestamp and sets the value in <milliseconds> from 1970-01-01T00:00. <milliseconds> must be an integer
+|Example: `Timestamp!fromMilliseconds(milliseconds = 60000)` is `&#x60;1970-01-01T00:01:00&#x60;`
 |======================================================================
 
 
@@ -807,18 +835,18 @@ At least one parameter is required, but any parameter can be used in conjunction
 
 Examples:
 
-`&#x60;2019-07-18T01:11:12Z&#x60;!plus(days = 1)` is `"2019-07-19T01:11:12Z"`
+`&#x60;2019-07-18T01:11:12&#x60;!plus(days = 1)` is `"2019-07-19T01:11:12"`
 
-`&#x60;2019-07-18T01:11:12Z&#x60;!plus(days = 1, hours = 2)` is `"2019-07-19T03:11:12Z"`
+`&#x60;2019-07-18T01:11:12&#x60;!plus(days = 1, hours = 2)` is `"2019-07-19T03:11:12"`
 
-`&#x60;2019-07-18T01:11:12Z&#x60;!plus(days = 1, hours = -24)` is `"2019-07-18T01:11:12Z"`
+`&#x60;2019-07-18T01:11:12&#x60;!plus(days = 1, hours = -24)` is `"2019-07-18T01:11:12"`
 |======================================================================
 
 [options="header",grid="none",cols="1a"]
 |======================================================================
 |`[purple]#**asString()**# : string`
 |Timestamp value as string according to the ISO-8601 standard.
-|Example: `&#x60;2019-07-18T01:11:12Z&#x60;!asString()` is `"2019-07-18T01:11:12Z"`
+|Example: `&#x60;2019-07-18T01:11:12Z&#x60;!asString()` is `"2019-07-18T01:11:12"`
 |======================================================================
 
 [#binary_functions,judo-req="true",judo-req-id="REQ-EXPR-019"]

--- a/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/PrimitiveDefaultValuesTests.xtend
+++ b/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/PrimitiveDefaultValuesTests.xtend
@@ -271,6 +271,7 @@ class PrimitiveDefaultValuesTests {
                 field Time timeHMS1 = Time!of(hour = 11, minute = 11, second = 11);
                 field Time timeHMSF = `11:11:11.111`;
                 field Time timeHMSF1 = Time!of(hour = 11, minute = 11, second = 11, millisecond = 111);
+                field Time timeHMSF2 = Time!of(hour = 11, minute = 11, millisecond = 111);
                 field Time timeFromMillisecond = Time!fromMilliseconds(milliseconds = 999999);
                 field Integer timeAsMillisecond = `11:11:11.111`!asMilliseconds();
                 field Timestamp timestamp = `2023-03-21T11:11`;
@@ -291,9 +292,10 @@ class PrimitiveDefaultValuesTests {
                 field Timestamp timestamp15 = `2023-03-21T11:11:11.111-05`;
                 field Timestamp timestamp16 = `2023-03-21T11:11:11.111+05:05`;
                 field Timestamp timestamp17 = `2023-03-21T11:11:11.111-05:05`;
-                field Timestamp timestamp18 = Timestamp!of(date = `2023-03-21`, time = `11:11`);
-                field Timestamp timestamp19 = Timestamp!of(date = `2023-03-21`, time = `11:11:11`);
-                field Timestamp timestamp20 = Timestamp!of(date = `2023-03-21`, time = `11:11:11.111`);
+                field Timestamp timestamp18 = Timestamp!of(date = `2023-03-21`);
+                field Timestamp timestamp19 = Timestamp!of(date = `2023-03-21`, time = `11:11`);
+                field Timestamp timestamp20 = Timestamp!of(date = `2023-03-21`, time = `11:11:11`);
+                field Timestamp timestamp21 = Timestamp!of(date = `2023-03-21`, time = `11:11:11.111`);
             }
 
             error ErrorFields {

--- a/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/PrimitiveDefaultValuesTests.xtend
+++ b/model-test/src/test/java/hu/blackbelt/judo/meta/jsl/runtime/PrimitiveDefaultValuesTests.xtend
@@ -265,8 +265,35 @@ class PrimitiveDefaultValuesTests {
                 field String c = "123";
                 field String c2 = r"123";
                 field Date d = `2020-01-12`;
-                field Time e = `22:45:22`;
-                field Timestamp f = `2020-01-12T12:12:12.000Z`;
+                field Time timeHM = `11:11`;
+                field Time timeHM1 = Time!of(hour = 11, minute = 11);
+                field Time timeHMS = `11:11:11`;
+                field Time timeHMS1 = Time!of(hour = 11, minute = 11, second = 11);
+                field Time timeHMSF = `11:11:11.111`;
+                field Time timeHMSF1 = Time!of(hour = 11, minute = 11, second = 11, millisecond = 111);
+                field Time timeFromMillisecond = Time!fromMilliseconds(milliseconds = 999999);
+                field Integer timeAsMillisecond = `11:11:11.111`!asMilliseconds();
+                field Timestamp timestamp = `2023-03-21T11:11`;
+                field Timestamp timestamp1 = `2023-03-21T11:11Z`;
+                field Timestamp timestamp2 = `2023-03-21T11:11+05`;
+                field Timestamp timestamp3 = `2023-03-21T11:11-05`;
+                field Timestamp timestamp4 = `2023-03-21T11:11+05:05`;
+                field Timestamp timestamp5 = `2023-03-21T11:11-05:05`;
+                field Timestamp timestamp6 = `2023-03-21T11:11:11`;
+                field Timestamp timestamp7 = `2023-03-21T11:11:11Z`;
+                field Timestamp timestamp8 = `2023-03-21T11:11:11+05`;
+                field Timestamp timestamp9 = `2023-03-21T11:11:11-05`;
+                field Timestamp timestamp10 = `2023-03-21T11:11:11+05:05`;
+                field Timestamp timestamp11 = `2023-03-21T11:11:11-05:05`;
+                field Timestamp timestamp12 = `2023-03-21T11:11:11.111`;
+                field Timestamp timestamp13 = `2023-03-21T11:11:11.111Z`;
+                field Timestamp timestamp14 = `2023-03-21T11:11:11.111+05`;
+                field Timestamp timestamp15 = `2023-03-21T11:11:11.111-05`;
+                field Timestamp timestamp16 = `2023-03-21T11:11:11.111+05:05`;
+                field Timestamp timestamp17 = `2023-03-21T11:11:11.111-05:05`;
+                field Timestamp timestamp18 = Timestamp!of(date = `2023-03-21`, time = `11:11`);
+                field Timestamp timestamp19 = Timestamp!of(date = `2023-03-21`, time = `11:11:11`);
+                field Timestamp timestamp20 = Timestamp!of(date = `2023-03-21`, time = `11:11:11.111`);
             }
 
             error ErrorFields {

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
@@ -833,7 +833,7 @@ terminal fragment NEWLINE
     ;
 
 terminal TIMESTAMP
-	: '`' DIGIT+ '-' DIGIT DIGIT '-' DIGIT DIGIT 'T' DIGIT DIGIT ':' DIGIT DIGIT (':' DIGIT DIGIT ('.' DIGIT+ )? )? ('Z' | ('+' | '-') DIGIT DIGIT ':' DIGIT DIGIT )'`'
+	: '`' DIGIT+ '-' DIGIT DIGIT '-' DIGIT DIGIT 'T' DIGIT DIGIT ':' DIGIT DIGIT (':' DIGIT DIGIT ('.' DIGIT+)?)? ('Z' | ('+' | '-') DIGIT DIGIT (':' DIGIT DIGIT)?)?'`'
 	;
 
 terminal TIME

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/JslDsl.xtext
@@ -752,7 +752,7 @@ StringLiteral
 
 TemporalLiteral
 	: {DateLiteral} value=DATE
-	| {TimeStampLiteral} value=TIMESTAMP
+	| {TimestampLiteral} value=TIMESTAMP
 	| {TimeLiteral} value=TIME
 	;
 

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/runtime/JslTerminalConverters.java
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/runtime/JslTerminalConverters.java
@@ -194,7 +194,7 @@ public class JslTerminalConverters extends DefaultTerminalConverters {
 	}
 
 	@ValueConverter(rule = "TIMESTAMP")
-	public IValueConverter<String> getTimeStampTerminalConverter() {
+	public IValueConverter<String> getTimestampTerminalConverter() {
 		return new IValueConverter<String>() {
 
 			@Override

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/runtime/TypeInfo.java
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/runtime/TypeInfo.java
@@ -50,7 +50,7 @@ import hu.blackbelt.judo.meta.jsl.jsldsl.ServiceDataDeclaration;
 import hu.blackbelt.judo.meta.jsl.jsldsl.SingleType;
 import hu.blackbelt.judo.meta.jsl.jsldsl.TernaryOperation;
 import hu.blackbelt.judo.meta.jsl.jsldsl.TimeLiteral;
-import hu.blackbelt.judo.meta.jsl.jsldsl.TimeStampLiteral;
+import hu.blackbelt.judo.meta.jsl.jsldsl.TimestampLiteral;
 import hu.blackbelt.judo.meta.jsl.jsldsl.TransferDeclaration;
 import hu.blackbelt.judo.meta.jsl.jsldsl.TransferFieldDeclaration;
 import hu.blackbelt.judo.meta.jsl.jsldsl.TypeDescription;
@@ -684,7 +684,7 @@ public class TypeInfo {
 			return new TypeInfo(BaseType.DATE, true);
 		} else if (litreal instanceof TimeLiteral) {
 			return new TypeInfo(BaseType.TIME, true);
-		} else if (litreal instanceof TimeStampLiteral) {
+		} else if (litreal instanceof TimestampLiteral) {
 			return new TypeInfo(BaseType.TIMESTAMP, true);
 		} else if (litreal instanceof EnumLiteralReference) {
 			return getTargetType( (EnumLiteralReference) litreal);

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/scoping/JudoFunctionsProvider.xtend
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/scoping/JudoFunctionsProvider.xtend
@@ -132,9 +132,10 @@ class JudoFunctionsProvider {
 		function numeric hour() on time;
 		function numeric minute() on time;
 		function numeric second() on time;
-		function time fromSeconds(required numeric seconds) on declaration<time>;
-		function numeric asSeconds() on time;
-		function time of(required numeric hour, required numeric minute, required numeric second) on declaration<time>;
+		function numeric millisecond() on time;
+		function time fromMilliseconds(required numeric milliseconds) on declaration<time>;
+		function numeric asMilliseconds() on time;
+		function time of(required numeric hour, required numeric minute, numeric second, numeric millisecond) on declaration<time>;
 		function string asString() on time;
 		
 		function timestamp now() on declaration<timestamp>;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-3902" title="JNG-3902" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-3902</a>  Timestamp.asString() produces wrong output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-3902_Fix_timestamp_asstring