### PR TITLE
JNG-4670 fixed Autocomplete does not use alias name

### DIFF
--- a/ide/preview-plantuml/src/main/java/hu/blackbelt/judo/meta/jsl/ui/preview/JslEditorDiagramIntentProvider.java
+++ b/ide/preview-plantuml/src/main/java/hu/blackbelt/judo/meta/jsl/ui/preview/JslEditorDiagramIntentProvider.java
@@ -46,7 +46,11 @@ public class JslEditorDiagramIntentProvider extends AbstractDiagramIntentProvide
             try {
                 if (state.getContents().size() > 0 && state.getContents().get(0) instanceof ModelDeclaration) {
                     ModelDeclaration m = (ModelDeclaration) state.getContents().get(0);
-                    return m;
+                    if (m != null && m.eResource().getErrors().size() == 0) {
+                    	return m;
+                    } else {
+                    	return null;
+                    }
                 } else {
                     return null;
                 }

--- a/model/src/main/java/hu/blackbelt/judo/meta/jsl/scoping/JslDslImportNormalizer.xtend
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jsl/scoping/JslDslImportNormalizer.xtend
@@ -13,10 +13,12 @@ class JslDslImportNormalizer extends ImportNormalizer {
     }
 
     override deresolve(QualifiedName fullyQualifiedName) {
-        if (fullyQualifiedName.empty || fullyQualifiedName.segmentCount != importedNamespacePrefix.segmentCount + 1) return null;
-
         if (fullyQualifiedName.startsWith(importedNamespacePrefix)) {
-            return fullyQualifiedName.skipFirst(importedNamespacePrefix.getSegmentCount());
+	        if (alias !== null) {
+	            return QualifiedName.create(alias).append(fullyQualifiedName.skipFirst(importedNamespacePrefix.getSegmentCount()));
+			} else {
+		    	return fullyQualifiedName.skipFirst(importedNamespacePrefix.getSegmentCount());
+			}
         }
 
         return null;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4670" title="JNG-4670" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4670</a>  Autocomplete does not use alias name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-4924 Generate PlantUML diagram only for valid model